### PR TITLE
Add NIPS conference papers data set

### DIFF
--- a/observations/__init__.py
+++ b/observations/__init__.py
@@ -11,6 +11,7 @@ from observations.enwik8 import enwik8
 from observations.iris import iris
 from observations.lsun import lsun
 from observations.mnist import mnist
+from observations.nips import nips
 from observations.ptb import ptb
 from observations.sick import sick
 from observations.small32_imagenet import small32_imagenet

--- a/observations/boston_housing.py
+++ b/observations/boston_housing.py
@@ -9,8 +9,8 @@ from observations.util import maybe_download_and_extract
 
 def boston_housing(path):
   """Load the Boston Housing data set (Harrison and Rubinfeld, 1978).
-    It contains 506 examples of housing values in suburbs of Boston,
-    each with 13 continuous attributes and 1 binary attribute.
+  It contains 506 examples of housing values in suburbs of Boston,
+  each with 13 continuous attributes and 1 binary attribute.
 
   Args:
     path: str.

--- a/observations/nips.py
+++ b/observations/nips.py
@@ -27,7 +27,6 @@ def nips(path, year=None):
       `year` and words appearing at least once in the document subset.
 
   Returns:
-    # TODO c.f., other returns for returning metadata
     Tuple of np.darray `x_train`, column headers `documents`, and row
     headers `words`.
   """

--- a/observations/nips.py
+++ b/observations/nips.py
@@ -9,7 +9,7 @@ import os
 from observations.util import maybe_download_and_extract
 
 
-def nips(path, year=None):
+def nips(path):
   """Load the NIPS conference papers 1987-2015 data set (Perrone et
   al., 2016). It is in the form of a 11,463 x 5,812 matrix of word
   counts, containing 11,463 words and 5,811 NIPS conference papers
@@ -22,18 +22,11 @@ def nips(path, year=None):
     path: str.
       Path to directory which either stores file or otherwise file will
       be downloaded and extracted there. Filename is `NIPS_1987-2015.csv`.
-    year: int, str, or list, optional.
-      Year or list of years. We subset to documents in `year` and
-      words appearing at least once in the subset of documents.
 
   Returns:
-    Tuple of np.darray `x_train`, column headers `documents`, and row
-    headers `words`.
+    Tuple of np.darray `x_train` and dictionary `metadata` of column
+    headers (documents) and row headers (words).
   """
-  if isinstance(year, int) or isinstance(year, str):
-    year = [str(year)]
-  elif isinstance(year, list):
-    year = [str(yr) for yr in year]
   path = os.path.expanduser(path)
   filename = 'NIPS_1987-2015.csv'
   if not os.path.exists(os.path.join(path, filename)):
@@ -50,13 +43,5 @@ def nips(path, year=None):
       x_train.append(row[1:])
 
   x_train = np.array(x_train, dtype=np.int)
-  if year is not None:
-    doc_idx = [i for i, document in enumerate(documents)
-               if document.startswith(tuple(year))]
-    documents = [documents[doc] for doc in doc_idx]
-    x_train = x_train[:, doc_idx]
-    word_idx = np.sum(x_train, 1) != 0
-    words = [words[word] for word in word_idx]
-    x_train = x_train[word_idx, :]
-
-  return x_train, documents, words
+  metadata = {'columns': documents, 'rows': words}
+  return x_train, metadata

--- a/observations/nips.py
+++ b/observations/nips.py
@@ -22,16 +22,18 @@ def nips(path, year=None):
     path: str.
       Path to directory which either stores file or otherwise file will
       be downloaded and extracted there. Filename is `NIPS_1987-2015.csv`.
-    year: int or list, optional.
-      Year or list of years to subset data. We subset to documents in
-      `year` and words appearing at least once in the document subset.
+    year: int, str, or list, optional.
+      Year or list of years. We subset to documents in `year` and
+      words appearing at least once in the subset of documents.
 
   Returns:
     Tuple of np.darray `x_train`, column headers `documents`, and row
     headers `words`.
   """
-  if isinstance(year, int):
-    year = [year]
+  if isinstance(year, int) or isinstance(year, str):
+    year = [str(year)]
+  elif isinstance(year, list):
+    year = [str(yr) for yr in year]
   path = os.path.expanduser(path)
   filename = 'NIPS_1987-2015.csv'
   if not os.path.exists(os.path.join(path, filename)):

--- a/observations/nips.py
+++ b/observations/nips.py
@@ -1,0 +1,61 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import csv
+import numpy as np
+import os
+
+from observations.util import maybe_download_and_extract
+
+
+def nips(path, year=None):
+  """Load the NIPS conference papers 1987-2015 data set (Perrone et
+  al., 2016). It is in the form of a 11,463 x 5,812 matrix of word
+  counts, containing 11,463 words and 5,811 NIPS conference papers
+  (the first column contains the list of words). Each column contains
+  the number of times each word appears in the corresponding document.
+  The names of the columns give information about each document and
+  its timestamp in the following format: `year_paperID`.
+
+  Args:
+    path: str.
+      Path to directory which either stores file or otherwise file will
+      be downloaded and extracted there. Filename is `NIPS_1987-2015.csv`.
+    year: int or list, optional.
+      Year or list of years to subset data. We subset to documents in
+      `year` and words appearing at least once in the document subset.
+
+  Returns:
+    # TODO c.f., other returns for returning metadata
+    Tuple of np.darray `x_train`, column headers `documents`, and row
+    headers `words`.
+  """
+  if isinstance(year, int):
+    year = [year]
+  path = os.path.expanduser(path)
+  filename = 'NIPS_1987-2015.csv'
+  if not os.path.exists(os.path.join(path, filename)):
+    url = 'https://archive.ics.uci.edu/ml/machine-learning-databases/00371/NIPS_1987-2015.csv'
+    maybe_download_and_extract(path, url)
+
+  with open(os.path.join(path, filename)) as f:
+    iterator = csv.reader(f)
+    documents = next(iterator)[1:]
+    words = []
+    x_train = []
+    for row in iterator:
+      words.append(row[0])
+      x_train.append(row[1:])
+
+  x_train = np.array(x_train, dtype=np.int)
+  if year is not None:
+    doc_idx = [i for i, document in enumerate(documents)
+               if document.startswith(tuple(year))]
+    documents = [documents[doc] for doc in doc_idx]
+    x_train = x_train[:, doc_idx]
+    word_idx = np.sum(x_train, 1) != 0
+    words = [words[word] for word in word_idx]
+    x_train = x_train[word_idx, :]
+
+  return x_train, documents, words


### PR DESCRIPTION
An open question is how to deal with metadata such as in NIPS' row and column headers (the corresponding words and documents respectively). Here are some options:

1. Previous data sets that involved more structure typically used dictionaries suck as `sick.py`. This seems like overkill for this problem.
2. Use a Pandas data frame. This breaks the standard of returning NumPy arrays.
3. Return a tuple in the style of the NumPy array and then the metadata. This breaks the standard where each returned element in a tuple has the same type (e.g., a tuple of NumPy arrays).

For now, let's do 3. See also `boston_housing.py` and `iris.py` which could download and return metadata but do not.