### PR TITLE
Add all data loading functions that Edward uses in examples

### DIFF
--- a/observations/__init__.py
+++ b/observations/__init__.py
@@ -6,6 +6,7 @@ from observations.abalone import abalone
 from observations.boston_housing import boston_housing
 from observations.caltech101_silhouettes import caltech101_silhouettes
 from observations.celeba import celeba
+from observations.celegans import celegans
 from observations.cifar10 import cifar10
 from observations.cifar100 import cifar100
 from observations.crabs import crabs

--- a/observations/__init__.py
+++ b/observations/__init__.py
@@ -8,6 +8,7 @@ from observations.caltech101_silhouettes import caltech101_silhouettes
 from observations.celeba import celeba
 from observations.cifar10 import cifar10
 from observations.cifar100 import cifar100
+from observations.crabs import crabs
 from observations.enwik8 import enwik8
 from observations.fashion_mnist import fashion_mnist
 from observations.iris import iris

--- a/observations/__init__.py
+++ b/observations/__init__.py
@@ -11,6 +11,7 @@ from observations.cifar100 import cifar100
 from observations.crabs import crabs
 from observations.enwik8 import enwik8
 from observations.fashion_mnist import fashion_mnist
+from observations.insteval import insteval
 from observations.iris import iris
 from observations.lsun import lsun
 from observations.mnist import mnist

--- a/observations/__init__.py
+++ b/observations/__init__.py
@@ -13,6 +13,7 @@ from observations.enwik8 import enwik8
 from observations.fashion_mnist import fashion_mnist
 from observations.insteval import insteval
 from observations.iris import iris
+from observations.karate import karate
 from observations.lsun import lsun
 from observations.mnist import mnist
 from observations.nips import nips

--- a/observations/abalone.py
+++ b/observations/abalone.py
@@ -39,7 +39,7 @@ def abalone(path):
       row[0] = encoder[row[0]]
       x_train.append(row)
   x_train = np.array(x_train, dtype=np.float)
-  columns = ['sex',
+  columns = ['sex (0 for M, 1 or F, 2 for I)',
              'length',
              'diameter',
              'height',

--- a/observations/celegans.py
+++ b/observations/celegans.py
@@ -1,0 +1,38 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import numpy as np
+import os
+
+from observations.util import maybe_download_and_extract
+
+
+def celegans(path):
+  """Load the neural network of the worm C. Elegans (Watts and
+  Strogatz, 1986). The neural network consists of around 300 neurons.
+  Each connection between neurons is associated with a weight
+  (positive integer) capturing the strength of the connection.
+
+  Args:
+    path: str.
+      Path to directory which either stores file or otherwise file will
+      be downloaded and extracted there. Filename is `celegansneural.gml`.
+
+  Returns:
+    Adjacency matrix as a np.darray `x_train` with 297 rows and 297
+    columns.
+  """
+  import networkx as nx
+  path = os.path.expanduser(path)
+  filename = 'celegansneural.gml'
+  if not os.path.exists(os.path.join(path, filename)):
+    url = 'http://www-personal.umich.edu/~mejn/netdata/celegansneural.zip'
+    maybe_download_and_extract(path, url)
+
+  graph = nx.read_gml(os.path.join(path, filename))
+  x_train = np.zeros([graph.number_of_nodes(), graph.number_of_nodes()],
+                     dtype=np.int)
+  for i, j in graph.edges():
+    x_train[i, j] = int(graph[i][j][0]['value'])
+  return x_train

--- a/observations/crabs.py
+++ b/observations/crabs.py
@@ -1,0 +1,56 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import csv
+import numpy as np
+import os
+
+from observations.util import maybe_download_and_extract
+
+
+def crabs(path):
+  """Load the Crabs data set (Campbell and Mahon, 1974). It contains
+  200 rows and 8 columns, describing 5 morphological measurements on
+  50 crabs each of two colour forms and both sexes, of the species
+  Leptograpsus variegatus collected at Fremantle, W. Australia.
+
+  Args:
+    path: str.
+      Path to directory which either stores file or otherwise file will
+      be downloaded and extracted there. Filename is `crabs.csv`.
+
+  Returns:
+    Tuple of np.darray `x_train` with 200 rows and 8 columns and
+    dictionary `metadata` of column headers (feature names).
+  """
+  path = os.path.expanduser(path)
+  filename = 'crabs.csv'
+  if not os.path.exists(os.path.join(path, filename)):
+    url = 'https://raw.github.com/vincentarelbundock/Rdatasets/master/csv/' \
+          'MASS/crabs.csv'
+    maybe_download_and_extract(path, url)
+
+  species_encoder = {'B': 0, 'O': 1}
+  sex_encoder = {'M': 0, 'F': 1}
+  with open(os.path.join(path, filename)) as f:
+    iterator = csv.reader(f)
+    _ = next(iterator)  # header
+    x_train = []
+    for row in iterator:
+      row = row[1:]
+      row[0] = species_encoder[row[0]]
+      row[1] = sex_encoder[row[1]]
+      x_train.append(row)
+
+  x_train = np.array(x_train, dtype=np.float)
+  columns = ['species (0 for blue, 1 for orange)',
+             'sex (0 for M, 1 or F)',
+             'index within each group'
+             'frontal lobe size (mm)',
+             'rear width (mm)',
+             'carapace length (mm)',
+             'carapace width (mm)',
+             'body depth (mm)']
+  metadata = {'columns': columns}
+  return x_train, metadata

--- a/observations/insteval.py
+++ b/observations/insteval.py
@@ -1,0 +1,41 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import csv
+import numpy as np
+import os
+
+from observations.util import maybe_download_and_extract
+
+
+def insteval(path):
+  """Load the InstEval data set. It contains 73,421 university lecture
+  evaluations by students at ETH Zurich with a total of 2,972
+  students, 2,160 professors and lecturers, and several student,
+  lecture, and lecturer attributes.
+
+  Args:
+    path: str.
+      Path to directory which either stores file or otherwise file will
+      be downloaded and extracted there. Filename is `insteval.csv`.
+
+  Returns:
+    Tuple of np.darray `x_train` with 73,421 rows and 7 columns and
+    dictionary `metadata` of column headers (feature names).
+  """
+  path = os.path.expanduser(path)
+  filename = 'InstEval.csv'
+  if not os.path.exists(os.path.join(path, filename)):
+    url = 'https://raw.github.com/vincentarelbundock/Rdatasets/master/csv/' \
+          'lme4/InstEval.csv'
+    maybe_download_and_extract(path, url)
+
+  with open(os.path.join(path, filename)) as f:
+    iterator = csv.reader(f)
+    columns = next(iterator)[1:]
+    x_train = []
+    x_train = np.array([row[1:] for row in iterator], dtype=np.int)
+
+  metadata = {'columns': columns}
+  return x_train, metadata

--- a/observations/karate.py
+++ b/observations/karate.py
@@ -1,0 +1,36 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+
+from observations.util import maybe_download_and_extract
+
+
+def karate(path):
+  """Load Zachary's Karate Club (Zachary, 1977). It is a social
+  network of friendships between 34 members of a karate club at a US
+  university from 1970 to 1972. During the study a conflict led the
+  club to split into two. Half of the members formed a new club around
+  the instructor; members from the other part found a new instructor
+  or gave up karate.
+
+  Args:
+    path: str.
+      Path to directory which either stores file or otherwise file will
+      be downloaded and extracted there. Filename is `karate.gml`.
+
+  Returns:
+    Adjacency matrix as a np.darray `x_train` with 34 rows and 34
+    columns.
+  """
+  import networkx as nx
+  path = os.path.expanduser(path)
+  filename = 'karate.gml'
+  if not os.path.exists(os.path.join(path, filename)):
+    url = 'http://www-personal.umich.edu/~mejn/netdata/karate.zip'
+    maybe_download_and_extract(path, url)
+
+  x_train = nx.read_gml(os.path.join(path, filename))
+  x_train = nx.to_numpy_matrix(x_train).astype(int)
+  return x_train

--- a/observations/karate.py
+++ b/observations/karate.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
 import os
 
 from observations.util import maybe_download_and_extract
@@ -10,10 +11,10 @@ from observations.util import maybe_download_and_extract
 def karate(path):
   """Load Zachary's Karate Club (Zachary, 1977). It is a social
   network of friendships between 34 members of a karate club at a US
-  university from 1970 to 1972. During the study a conflict led the
-  club to split into two. Half of the members formed a new club around
-  the instructor; members from the other part found a new instructor
-  or gave up karate.
+  university from 1970 to 1972. During the study a conflict between
+  instructor 'Mr. Hi' and administrator 'Officer' led the club to
+  split into two. Half of the members formed a new club around 'Mr.
+  Hi'; other members found a new instructor or quit karate.
 
   Args:
     path: str.
@@ -21,8 +22,9 @@ def karate(path):
       be downloaded and extracted there. Filename is `karate.gml`.
 
   Returns:
-    Adjacency matrix as a np.darray `x_train` with 34 rows and 34
-    columns.
+    Tuple of adjacency matrix as a np.darray `x_train` with 34 rows
+    and 34 columns and np.darray `y_train` of class memberships (0 for
+    'Mr.Hi' and 1 for 'Officer').
   """
   import networkx as nx
   path = os.path.expanduser(path)
@@ -33,4 +35,7 @@ def karate(path):
 
   x_train = nx.read_gml(os.path.join(path, filename))
   x_train = nx.to_numpy_matrix(x_train).astype(int)
-  return x_train
+  labels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 16, 17, 19, 21]
+  y_train = np.array([0 if i in labels else 1
+                      for i in range(x_train.shape[0])], dtype=np.int)
+  return x_train, y_train


### PR DESCRIPTION
Rant: Handling Newman's network data with the networkx library is a mess. I spent many needless hours on this. 

The short story is that networkx requires <=1.9.1 for `nx.read_gml` to just work on Newman's data files. networkx will raise an exception for any newer version. Alternatively, I tried supporting newer versions by modifying the data file and then calling `nx.parse_gml`. 

For `karate.py`, this is doable.
```python
import re

with open(os.path.join(path, filename)) as f:
  x_train = ''.join(f.readlines()[1:])

x_train = re.sub('\s+\[', ' [', x_train)
x_train = nx.parse_gml(x_train, label='id')
x_train = nx.to_numpy_matrix(x_train).astype(int)
```

For `celegans.py`, the situation is crazier.
```python
import re

with open(os.path.join(path, filename)) as f:
 x_train = ''.join(f.readlines()[1:]).replace("value", "weight")

x_train = re.sub('\s+\[', ' [', x_train)
x_train = nx.parse_gml(x_train, label='id')
```
This yet again raises an error with the latest stable version (~1.11) because `parse_gml` can't handle multigraphs (apparently Newman's `celegansbrains.nml` has duplicate edges). Using a development version of networkx as an alternative, calling
```python
x_train = nx.to_numpy_matrix(x_train).astype(int)
```
still does not work as intended until you try to sum up all the edge weights like so:
```python
G = nx.Graph()
M = x_train
for u,v,_ in M.edges:
 data = M[u][v]
 for item in data.values():
   w = item['weight'] if 'weight' in item else 1.0
 if G.has_edge(u,v):
   G[u][v]['weight'] += w
 else:
   G.add_edge(u, v, weight=w)
```
(The above still doesn't sum up the edge weights correctly.)