### PR TITLE
Improved downloader with better progress/pause & resume/hash verification

### DIFF
--- a/observations/cifar10.py
+++ b/observations/cifar10.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import numpy as np
 import os
+import six
 import sys
 
 from observations.util import maybe_download_and_extract

--- a/observations/cifar100.py
+++ b/observations/cifar100.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import numpy as np
 import os
+import six
 import sys
 
 from observations.util import maybe_download_and_extract

--- a/observations/ptb.py
+++ b/observations/ptb.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import collections
+import io
 import os
 
 from observations.util import maybe_download_and_extract
@@ -29,10 +30,13 @@ def ptb(path):
     maybe_download_and_extract(path, url)
 
   path = os.path.join(path, 'simple-examples/data')
-  with open(os.path.join(path, 'ptb.train.txt')) as f:
-    x_train = f.read().decode("utf-8").replace("\n", "<eos>")
-  with open(os.path.join(path, 'ptb.test.txt')) as f:
-    x_test = f.read().decode("utf-8").replace("\n", "<eos>")
-  with open(os.path.join(path, 'ptb.valid.txt')) as f:
-    x_valid = f.read().decode("utf-8").replace("\n", "<eos>")
+  with io.open(os.path.join(path, 'ptb.train.txt'),
+               encoding='utf-8') as f:
+    x_train = f.read().replace("\n", "<eos>")
+  with io.open(os.path.join(path, 'ptb.test.txt'),
+               encoding='utf-8') as f:
+    x_test = f.read().replace("\n", "<eos>")
+  with io.open(os.path.join(path, 'ptb.valid.txt'),
+               encoding='utf-8') as f:
+    x_valid = f.read().replace("\n", "<eos>")
   return x_train, x_test, x_valid

--- a/observations/util.py
+++ b/observations/util.py
@@ -64,7 +64,7 @@ def maybe_download_and_extract(directory, url, extract=True):
       with gzip.open(filepath, 'rb') as f:
         s = f.read()
       extracted_filepath = os.path.splitext(filepath)[0]
-      with open(extracted_filepath, 'w') as f:
+      with open(extracted_filepath, 'wb') as f:
         f.write(s)
     elif zipfile.is_zipfile(filepath):
       with zipfile.ZipFile(filepath) as f:

--- a/observations/wikitext103.py
+++ b/observations/wikitext103.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import io
 import os
 
 from observations.util import maybe_download_and_extract
@@ -40,12 +41,15 @@ def wikitext103(path, raw=False):
     maybe_download_and_extract(path, url)
 
   path = os.path.join(path, directory)
-  with open(os.path.join(path, 'wiki.train' + extension)) as f:
-    x_train = f.read().decode("utf-8")
-  with open(os.path.join(path, 'wiki.test' + extension)) as f:
-    x_test = f.read().decode("utf-8")
-  with open(os.path.join(path, 'wiki.valid' + extension)) as f:
-    x_valid = f.read().decode("utf-8")
+  with io.open(os.path.join(path, 'wiki.train' + extension),
+               encoding='utf-8') as f:
+    x_train = f.read()
+  with io.open(os.path.join(path, 'wiki.test' + extension),
+               encoding='utf-8') as f:
+    x_test = f.read()
+  with io.open(os.path.join(path, 'wiki.valid' + extension),
+               encoding='utf-8') as f:
+    x_valid = f.read()
   if not raw:
     x_train = x_train.replace("\n", "<eos>")
     x_test = x_test.replace("\n", "<eos>")

--- a/observations/wikitext2.py
+++ b/observations/wikitext2.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import io
 import os
 
 from observations.util import maybe_download_and_extract
@@ -40,12 +41,15 @@ def wikitext2(path, raw=False):
     maybe_download_and_extract(path, url)
 
   path = os.path.join(path, directory)
-  with open(os.path.join(path, 'wiki.train' + extension)) as f:
-    x_train = f.read().decode("utf-8")
-  with open(os.path.join(path, 'wiki.test' + extension)) as f:
-    x_test = f.read().decode("utf-8")
-  with open(os.path.join(path, 'wiki.valid' + extension)) as f:
-    x_valid = f.read().decode("utf-8")
+  with io.open(os.path.join(path, 'wiki.train' + extension),
+               encoding='utf-8') as f:
+    x_train = f.read()
+  with io.open(os.path.join(path, 'wiki.test' + extension),
+               encoding='utf-8') as f:
+    x_test = f.read()
+  with io.open(os.path.join(path, 'wiki.valid' + extension),
+               encoding='utf-8') as f:
+    x_valid = f.read()
   if not raw:
     x_train = x_train.replace("\n", "<eos>")
     x_test = x_test.replace("\n", "<eos>")


### PR DESCRIPTION
Addressing few of the issues raised by you to support
a) Better progress update giving ETA/Speed
b) Human readable size and time 
c) pause/resume downloads with resume=True option
d) hash verification if hash is provided (hash_true option)
e) Some fixes in other files (import six missing)

I have created a new file download_utils which has the logic for the above
The utils maybe_download_and_extract has two new flags (resume=False & hash_true=None). I have enabled resume=True for LSUN as I faced problems when downloading this dataset and hence the PR