### PR TITLE
Changed karate to use edgelist instead of gml

### DIFF
--- a/observations/karate.py
+++ b/observations/karate.py
@@ -19,7 +19,7 @@ def karate(path):
   Args:
     path: str.
       Path to directory which either stores file or otherwise file will
-      be downloaded and extracted there. Filename is `karate.gml`.
+      be downloaded and extracted there. Filename is `out.ucidata-zachary`.
 
   Returns:
     Tuple of adjacency matrix as a np.darray `x_train` with 34 rows
@@ -33,7 +33,7 @@ def karate(path):
     url = 'http://konect.uni-koblenz.de/downloads/tsv/ucidata-zachary.tar.bz2'
     maybe_download_and_extract(path, url)
 
-  node_order = [str(i) for i in range(1,35)]
+  node_order = [str(i) for i in range(1, 35)]
   x_train = nx.read_edgelist(os.path.join(path, filename), comments='%')
   x_train = nx.to_numpy_matrix(x_train, node_order).astype(int)
   labels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 16, 17, 19, 21]

--- a/observations/karate.py
+++ b/observations/karate.py
@@ -28,13 +28,14 @@ def karate(path):
   """
   import networkx as nx
   path = os.path.expanduser(path)
-  filename = 'karate.gml'
+  filename = 'ucidata-zachary/out.ucidata-zachary'
   if not os.path.exists(os.path.join(path, filename)):
-    url = 'http://www-personal.umich.edu/~mejn/netdata/karate.zip'
+    url = 'http://konect.uni-koblenz.de/downloads/tsv/ucidata-zachary.tar.bz2'
     maybe_download_and_extract(path, url)
 
-  x_train = nx.read_gml(os.path.join(path, filename))
-  x_train = nx.to_numpy_matrix(x_train).astype(int)
+  node_order = [str(i) for i in range(1,35)]
+  x_train = nx.read_edgelist(os.path.join(path, filename), comments='%')
+  x_train = nx.to_numpy_matrix(x_train, node_order).astype(int)
   labels = [0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 16, 17, 19, 21]
   y_train = np.array([0 if i in labels else 1
                       for i in range(x_train.shape[0])], dtype=np.int)


### PR DESCRIPTION
The current karate.py uses read_gml which is not version agnostic. If networkx > 1.9.1 is used, then it breaks due to the changes in read_gml to support for labeling. Additionally, there's a bug with gml parsing in networkx from version 1.10 to 1.11.

Instead, I suggest using edgelist which is consistent across all networkx version. The dataset is obtained from another network repository: http://konect.uni-koblenz.de/networks/ucidata-zachary which has an edgelist version available instead of gml.